### PR TITLE
Add log throttling per file

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -74,8 +74,8 @@ module Fluent::Plugin
     config_param :refresh_interval, :time, default: 60
     desc 'The number of reading lines at each IO.'
     config_param :read_lines_limit, :integer, default: 1000
-    desc 'The number of reading lines per notify'
-    config_param :read_lines_limit_per_notify, :integer, default: -1
+    desc 'The number of reading bytes per second'
+    config_param :read_bytes_limit_per_second, :integer, default: -1
     desc 'The interval of flushing the buffer for multiline format'
     config_param :multiline_flush_interval, :time, default: nil
     desc 'Enable the option to emit unmatched lines.'
@@ -285,7 +285,7 @@ module Fluent::Plugin
 
     def setup_watcher(path, pe)
       line_buffer_timer_flusher = (@multiline_mode && @multiline_flush_interval) ? TailWatcher::LineBufferTimerFlusher.new(log, @multiline_flush_interval, &method(:flush_buffer)) : nil
-      tw = TailWatcher.new(path, @rotate_wait, pe, log, @read_from_head, @enable_watch_timer, @enable_stat_watcher, @read_lines_limit, @read_lines_limit_per_notify, method(:update_watcher), line_buffer_timer_flusher, @from_encoding, @encoding, open_on_every_update, &method(:receive_lines))
+      tw = TailWatcher.new(path, @rotate_wait, pe, log, @read_from_head, @enable_watch_timer, @enable_stat_watcher, @read_lines_limit, @read_bytes_limit_per_second, method(:update_watcher), line_buffer_timer_flusher, @from_encoding, @encoding, open_on_every_update, &method(:receive_lines))
       tw.attach do |watcher|
         event_loop_attach(watcher.timer_trigger) if watcher.timer_trigger
         event_loop_attach(watcher.stat_trigger) if watcher.stat_trigger
@@ -496,7 +496,7 @@ module Fluent::Plugin
     end
 
     class TailWatcher
-      def initialize(path, rotate_wait, pe, log, read_from_head, enable_watch_timer, enable_stat_watcher, read_lines_limit, read_lines_limit_per_notify, update_watcher, line_buffer_timer_flusher, from_encoding, encoding, open_on_every_update, &receive_lines)
+      def initialize(path, rotate_wait, pe, log, read_from_head, enable_watch_timer, enable_stat_watcher, read_lines_limit, read_bytes_limit_per_second, update_watcher, line_buffer_timer_flusher, from_encoding, encoding, open_on_every_update, &receive_lines)
         @path = path
         @rotate_wait = rotate_wait
         @pe = pe || MemoryPositionEntry.new
@@ -504,7 +504,7 @@ module Fluent::Plugin
         @enable_watch_timer = enable_watch_timer
         @enable_stat_watcher = enable_stat_watcher
         @read_lines_limit = read_lines_limit
-        @read_lines_limit_per_notify = read_lines_limit_per_notify
+        @read_bytes_limit_per_second = read_bytes_limit_per_second
         @receive_lines = receive_lines
         @update_watcher = update_watcher
 
@@ -522,7 +522,7 @@ module Fluent::Plugin
       end
 
       attr_reader :path
-      attr_reader :log, :pe, :read_lines_limit, :read_lines_limit_per_notify, :open_on_every_update
+      attr_reader :log, :pe, :read_lines_limit, :read_bytes_limit_per_second, :open_on_every_update
       attr_reader :from_encoding, :encoding
       attr_reader :stat_trigger, :enable_watch_timer, :enable_stat_watcher
       attr_accessor :timer_trigger
@@ -750,22 +750,25 @@ module Fluent::Plugin
         def handle_notify
           with_io do |io|
             begin
+              bytes_to_read = 8192
+              number_bytes_read = 0
               read_more = false
 
               if !io.nil? && @lines.empty?
                 begin
                   while true
-                    @fifo << io.readpartial(8192, @iobuf)
+                    @fifo << io.readpartial(bytes_to_read, @iobuf)
                     @fifo.read_lines(@lines)
-                    limit_per_notify = @lines.size >= @watcher.read_lines_limit_per_notify and @watcher.read_lines_limit_per_notify > 0
-                    if limit_per_notify 
-                      # stop reading files when we reach the read lines limit per notify, to throttle the log ingestion
+                    number_bytes_read += bytes_to_read 
+                    limit_bytes_per_second_reached = (@lines.size >= @watcher.read_bytes_limit_per_second and @watcher.read_bytes_limit_per_second > 0)
+                    if limit_bytes_per_second_reached 
+                      # stop reading files when we reach the read bytes limit per second, to throttle the log ingestion
                       read_more = false
                     elsif @lines.size >= @watcher.read_lines_limit
                       # not to use too much memory in case the file is very large
                       read_more = true
                     end
-                    if @lines.size >= @watcher.read_lines_limit or limit_per_notify 
+                    if @lines.size >= @watcher.read_lines_limit or limit_bytes_per_second_reached 
                       break
                     end
 

--- a/test/plugin/test_in_tail.rb
+++ b/test/plugin/test_in_tail.rb
@@ -73,7 +73,7 @@ class TailInputTest < Test::Unit::TestCase
       assert_equal 2, d.instance.rotate_wait
       assert_equal "#{TMP_DIR}/tail.pos", d.instance.pos_file
       assert_equal 1000, d.instance.read_lines_limit
-      assert_equal -1, d.instance.read_lines_limit_per_notify
+      assert_equal -1, d.instance.read_bytes_limit_per_second
       assert_equal false, d.instance.ignore_repeated_permission_error
     end
 
@@ -213,17 +213,17 @@ class TailInputTest < Test::Unit::TestCase
       assert_equal(num_events, d.emit_count)
     end
 
-    data('flat 1' => [:flat, 100, 1, 10],
-         'flat 10' => [:flat, 100, 10, 20],
-         'parse 1' => [:parse, 100, 3, 10],
-         'parse 10' => [:parse, 100, 10, 20])
-    def test_emit_with_read_lines_limit_per_notify(data)
-      config_style, limit, limit_per_notify, num_events = data
+    data('flat 1' => [:flat, 100, 8192, 10],
+         'flat 10' => [:flat, 100, (8192 * 10), 20],
+         'parse 1' => [:parse, 100, (8192 * 3), 10],
+         'parse 10' => [:parse, 100, (8192 * 10), 20])
+    def test_emit_with_read_bytes_limit_per_second(data)
+      config_style, limit, limit_bytes, num_events = data
       case config_style
       when :flat
-        config = CONFIG_READ_FROM_HEAD + SINGLE_LINE_CONFIG + config_element("", "", { "read_lines_limit" => limit, "read_lines_limit_per_notify" => limit_per_notify })
+        config = CONFIG_READ_FROM_HEAD + SINGLE_LINE_CONFIG + config_element("", "", { "read_lines_limit" => limit, "read_bytes_limit_per_second" => limit_bytes })
       when :parse
-        config = CONFIG_READ_FROM_HEAD + config_element("", "", { "read_lines_limit" => limit, "read_lines_limit_per_notify" => limit_per_notify }) + PARSE_SINGLE_LINE_CONFIG
+        config = CONFIG_READ_FROM_HEAD + config_element("", "", { "read_lines_limit" => limit, "read_bytes_limit_per_second" => limit_bytes }) + PARSE_SINGLE_LINE_CONFIG
       end
       d = create_driver(config)
       msg = 'test' * 2000 # in_tail reads 8192 bytes at once.


### PR DESCRIPTION
**What this PR does / why we need it**: 
Running in a big cluster with high volume of log, it would be nice to throttle the log shipping to avoid network saturation and make it easier to calculate the max throughput per node for example in a Kubernetes cluster. 

Tail plugin is watching files and every second reading from the last pointer to the end of the file.
This change allow to stop reading the file after X number of logs lines read and update the pointer in the pos file as usual. 

**Docs Changes**:
- adding `read_lines_limit_per_notify` which by default is set to `-1`, so no throttling involve by default.
